### PR TITLE
#1 - Add ability to overwrite default port from .mock.yaml

### DIFF
--- a/.example.mock.yaml
+++ b/.example.mock.yaml
@@ -1,5 +1,5 @@
-# Example .mock.yaml config
-Port: 8089
+#Example .mock.yaml config
+#Port: 7071 #Optional, to overwrite the default port
 Endpoints:
   - Resource: /city/1
     Method: GET

--- a/.example.mock.yaml
+++ b/.example.mock.yaml
@@ -1,4 +1,5 @@
 # Example .mock.yaml config
+Port: 8089
 Endpoints:
   - Resource: /city/1
     Method: GET

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,6 +6,8 @@ import (
 	"github.com/bschaatsbergen/mock/utils"
 )
 
+const defaultPort = "7070"
+
 var cfgFile string
 var port string
 
@@ -22,11 +24,16 @@ The mock config can be passed by using the '-c' flag, otherwise by default from 
 
 func init() {
 	rootCmd.AddCommand(serveCmd)
-	serveCmd.Flags().StringVarP(&port, "port", "p", "7070", "binds a given port to mock")
+	serveCmd.Flags().StringVarP(&port, "port", "p", defaultPort, "binds a given port to mock")
 	serveCmd.Flags().StringVarP(&cfgFile, "config", "c", "", "overwrite the .mock.yaml from the working directory")
 }
 
 func Serve() {
 	conf := utils.ReadMockConfig(cfgFile)
+
+	if conf.Port != "" {
+		port = conf.Port
+	}
+
 	utils.StartServer(conf, port)
 }

--- a/model/config.go
+++ b/model/config.go
@@ -1,6 +1,7 @@
 package model
 
 type Config struct {
+	Port      string      `yaml:"Port"`
 	Endpoints []Endpoints `yaml:"Endpoints"`
 }
 

--- a/utils/write_config.go
+++ b/utils/write_config.go
@@ -8,7 +8,7 @@ import (
 
 const mockFileName = ".mock.yaml"
 
-var conf = `# Example .mock.yaml config
+var conf = `#Example .mock.yaml config
 #Port: 7071 #Optional, to overwrite the default port
 Endpoints:
   - Resource: /city/1

--- a/utils/write_config.go
+++ b/utils/write_config.go
@@ -9,6 +9,7 @@ import (
 const mockFileName = ".mock.yaml"
 
 var conf = `# Example .mock.yaml config
+#Port: 7071 #Optional, to overwrite the default port
 Endpoints:
   - Resource: /city/1
     Method: GET


### PR DESCRIPTION
Optional property that users can specify in the `.mock.yaml` to overwrite the default address `(:7070)`.